### PR TITLE
#4 Trim input string, add tests for string trimming

### DIFF
--- a/convert_text.py
+++ b/convert_text.py
@@ -1,7 +1,10 @@
 def convert_text(input_text, start_upper_case = None):
     if start_upper_case == None:
         start_upper_case = True
-    
+
+    #remove leading and trailing whitespace chars
+    input_text = input_text.strip();
+
     outputText = ""
     for index in range(len(input_text)):
 

--- a/tests.py
+++ b/tests.py
@@ -19,5 +19,22 @@ class TestCalculations(unittest.TestCase):
         output_text = convert_text(input_text, False)
         self.assertEqual(output_text, expected_output_start_lower_case)
 
+    # If trimmed AFTER conversion, the case will be opposite due whitespace being indexed
+    def test_string_trim_odd_number_of_spaces(self):
+        output_text = convert_text("   " + input_text + "   ", True)
+        self.assertEqual(output_text, expected_output_start_upper_case)
+
+    def test_string_trim_even_number_of_spaces(self):
+        output_text = convert_text("    " + input_text + "    ", True)
+        self.assertEqual(output_text, expected_output_start_upper_case)
+
+    def test_string_trim_newline(self):
+        output_text = convert_text("\n" + input_text + "\n", True)
+        self.assertEqual(output_text, expected_output_start_upper_case)
+
+    def test_string_trim_tab(self):
+        output_text = convert_text("\t" + input_text + "\t", True)
+        self.assertEqual(output_text, expected_output_start_upper_case)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I discovered that it's important to trim the string BEFORE converting it, because if you trim it after conversion, the end user will receive the opposite case due to an odd number of whitespaces.

Added tests for:
- Odd number of whitespace
- Even number of whitespace
- newline
- tab