### PR TITLE
#19 env var for acao header

### DIFF
--- a/convert_text.py
+++ b/convert_text.py
@@ -1,21 +1,31 @@
 import json
-
-JSON_KEY_INPUT_TEXT = "inputText"
-JSON_KEY_START_UPPER_CASE = "startUpperCase"
-JSON_KEY_CONVERTED_TEXT = "convertedText"
+import os
+from global_constants import *
 
 
 def lambda_handler(event, context):
-    body = json.loads(event['body'])
+    if os.environ.get(ACAO_ENV_VAR) is None:
+        print(ACAO_ENV_VAR_NOT_SET_ERROR_MESSAGE)
+        return {
+            STATUS_CODE_KEY: 500,
+            IS_BASE64_ENCODED_KEY: False,
+            HEADERS_KEY: {
+                CONTENT_TYPE_HEADER_KEY: CONTENT_TYPE_APPLICATION_JSON,
+                ACAO_HEADER_KEY: "*"
+            },
+            BODY_KEY: ACAO_ENV_VAR_NOT_SET_ERROR_MESSAGE
+        }
+
+    body = json.loads(event[BODY_KEY])
     json_output = {JSON_KEY_CONVERTED_TEXT: convert_text(body[JSON_KEY_INPUT_TEXT], body[JSON_KEY_START_UPPER_CASE])}
     return {
-        "statusCode": 200,
-        "isBase64Encoded": False,
-        "headers": {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": '*'
+        STATUS_CODE_KEY: 200,
+        IS_BASE64_ENCODED_KEY: False,
+        HEADERS_KEY: {
+            CONTENT_TYPE_HEADER_KEY: CONTENT_TYPE_APPLICATION_JSON,
+            ACAO_HEADER_KEY: os.environ.get(ACAO_ENV_VAR)
         },
-        "body": json.dumps(json_output)
+        BODY_KEY: json.dumps(json_output)
     }
 
 

--- a/global_constants.py
+++ b/global_constants.py
@@ -1,0 +1,17 @@
+# request payload keys
+JSON_KEY_INPUT_TEXT = "inputText"
+JSON_KEY_START_UPPER_CASE = "startUpperCase"
+
+# response payload keys
+STATUS_CODE_KEY = "statusCode"
+IS_BASE64_ENCODED_KEY = "isBase64Encoded"
+HEADERS_KEY = "headers"
+CONTENT_TYPE_HEADER_KEY = "Content-Type"
+CONTENT_TYPE_APPLICATION_JSON = "application/json"
+ACAO_HEADER_KEY = "Access-Control-Allow-Origin"
+BODY_KEY = "body"
+JSON_KEY_CONVERTED_TEXT = "convertedText"
+
+# ACAO env var
+ACAO_ENV_VAR = "MOCKING_TEXT_LAMBDA_ACAO"
+ACAO_ENV_VAR_NOT_SET_ERROR_MESSAGE = ACAO_HEADER_KEY + "header is not set on the server"


### PR DESCRIPTION
- Added env var for ACAO header
- Added a global constants and moved global constants out of main python file
- Added a response and log in case ACAO is not set

The ACAO header on the lambda is currently set to "*" but should be secured to the correct domain once the web project is in place

Added tests, all tests pass